### PR TITLE
Prevent ordering of custom blockmodel table

### DIFF
--- a/app.R
+++ b/app.R
@@ -1943,7 +1943,7 @@ server <- function(input, output) {
       ## Outputs
       TblCurrent
     },selection = list(mode="multiple",target='cell'),
-    options = list(paging =FALSE, searching=FALSE),style='bootstrap4')
+    options = list(paging =FALSE, searching=FALSE,ordering=FALSE),style='bootstrap4')
   }
 
 # Run the application 


### PR DESCRIPTION
Prevent ordering of custom blockmodel table.

I'm committing this mainly to test if this works.